### PR TITLE
Renamed Hangups System to Core, moved Auth to Core

### DIFF
--- a/Hangups/Core/Auth.cs
+++ b/Hangups/Core/Auth.cs
@@ -1,0 +1,133 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Security.Authentication.Web;
+
+namespace Hangups.Core
+{
+    public static class Auth
+    {
+        private static string oAuth_Scope = "https://www.google.com/accounts/OAuthLogin";
+        private static string client_secret = "KWsJlkaMn1jGLxQpWxMnOox-";
+        private static string client_id = "936475272427.apps.googleusercontent.com";
+        private static string redirect_uri = "urn:ietf:wg:oauth:2.0:oob";
+        private static string login_url = "https://accounts.google.com/o/oauth2/auth?{0}";
+        private static string token_request_url = "https://accounts.google.com/o/oauth2/token";
+
+       
+        public static void PerformOauth()
+        {
+            var refreshToken = SettingsHelper.GetStringSetting("refresh_token");
+
+            if(refreshToken != String.Empty)
+            {
+                PerformRefreshTokenOAuth(refreshToken);
+            }
+            else
+            {
+                PerformGoogleOAuth();
+            }
+        }
+
+        private async static void PerformGoogleOAuth()
+        {
+            var startUri = new Uri(string.Format(login_url, formatLoginURL()));
+            Uri EndUri = new Uri("https://accounts.google.com/o/oauth2/approval?");
+            try
+            {
+                WebAuthenticationResult WebAuthenticationResult = await WebAuthenticationBroker.AuthenticateAsync(WebAuthenticationOptions.UseTitle, startUri, EndUri);
+                if (WebAuthenticationResult.ResponseStatus == WebAuthenticationStatus.Success)
+                {
+                    PerformTokenAuth(WebAuthenticationResult.ResponseData.ToString().Split('=')[1]);
+                }
+                else if (WebAuthenticationResult.ResponseStatus == WebAuthenticationStatus.ErrorHttp)
+                {
+                    NotificationHelper.ErrorMessage("The result returned Error " + WebAuthenticationResult.ResponseErrorDetail.ToString(), "Authentication Failure");
+                }
+                else
+                {
+                    NotificationHelper.ErrorMessage("An unknown error has occurred", "Authentication Failed");
+                }
+            }
+
+
+            catch (Exception Error)
+            {
+                NotificationHelper.ErrorMessage(Error.Message, "Authentication Failed");
+            }
+        }
+
+        private async static void PerformTokenAuth(string authToken)
+        {
+            HttpClient aClient = new HttpClient();
+            var body = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("client_id", client_id),
+                new KeyValuePair<string, string>("client_secret", client_secret),
+                new KeyValuePair<string, string>("code", authToken),
+                new KeyValuePair<string, string>("grant_type", "authorization_code"),
+                new KeyValuePair<string, string>("redirect_uri", redirect_uri),
+            });
+
+            var response = await aClient.PostAsync(token_request_url, body);
+            response.EnsureSuccessStatusCode();
+
+            var resultContent = await response.Content.ReadAsStringAsync();
+            JObject returnedData = JObject.Parse(resultContent);
+            var accessToken = (string)returnedData.SelectToken("access_token");
+            SettingsHelper.StoreSetting("access_token", accessToken);
+            SettingsHelper.StoreSetting("refresh_token", (string)returnedData.SelectToken("refresh_token"));
+            GetCookies(accessToken);
+        }
+
+        private async static void PerformRefreshTokenOAuth(string refreshToken)
+        {
+            HttpClient aClient = new HttpClient();
+            var body = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("client_id", client_id),
+                new KeyValuePair<string, string>("client_secret", client_secret),
+                new KeyValuePair<string, string>("grant_type", "refresh_token"),
+                new KeyValuePair<string, string>("refresh_token", refreshToken)
+            });
+            var response = await aClient.PostAsync(token_request_url, body);
+            response.EnsureSuccessStatusCode();
+
+            var resultContent = await response.Content.ReadAsStringAsync();
+            JObject returnedData = JObject.Parse(resultContent);
+            var accessToken = (string)returnedData.SelectToken("access_token");
+            SettingsHelper.StoreSetting("access_token", accessToken);
+            GetCookies(accessToken);
+        }
+
+        private async static void GetCookies(string accessToken)
+        {
+            HttpClient aClient = new HttpClient();
+            aClient.DefaultRequestHeaders.Add("Authorization", string.Format("Bearer {0}", accessToken));
+            var r = await aClient.GetAsync("https://accounts.google.com/accounts/OAuthLogin?source=hangups&issueuberauth=1");
+            r.EnsureSuccessStatusCode();
+            var uberAuth = await r.Content.ReadAsStringAsync();
+            r = await aClient.GetAsync(String.Format("https://accounts.google.com/MergeSession?service=mail&continue=http://www.google.com&uberauth={0}", uberAuth));
+            r.EnsureSuccessStatusCode();
+            IEnumerable<string> cookies;
+            var responseCookies = new CookieContainer();
+            if (r.Headers.TryGetValues("set-cookie", out cookies))
+            {
+                foreach (var c in cookies)
+                {
+                    responseCookies.SetCookies(r.RequestMessage.RequestUri, c);
+                }
+            }
+        }
+
+        private static string formatLoginURL()
+        {
+            return "client_id=" + Uri.EscapeDataString(client_id) + "&redirect_uri=" + Uri.EscapeDataString(redirect_uri) + "&response_type=code&scope=" + Uri.EscapeDataString(oAuth_Scope);
+        }
+    }
+}

--- a/Hangups/Core/NotificationHelper.cs
+++ b/Hangups/Core/NotificationHelper.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Windows.UI.Notifications;
 
-namespace Hangups.HangupsSystem
+namespace Hangups.Core
 {
     class NotificationHelper
     {
@@ -82,6 +82,20 @@ namespace Hangups.HangupsSystem
                         }
                     }
                 }
+            });
+        }
+
+        public static void ErrorMessage(string message, string title)
+        {
+            Show(new ToastContent()
+            {
+                Visual = new ToastVisual()
+                {
+                    TitleText = new ToastText() { Text = title },
+                    BodyTextLine1 = new ToastText() { Text = message }
+                },
+
+                Scenario = ToastScenario.Default
             });
         }
     }

--- a/Hangups/Core/SettingsHelper.cs
+++ b/Hangups/Core/SettingsHelper.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Windows.Storage;
 
-namespace Hangups.HangupsSystem
+namespace Hangups.Core
 {
     public static class SettingsHelper
     {

--- a/Hangups/Hangups.csproj
+++ b/Hangups/Hangups.csproj
@@ -98,8 +98,9 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
-    <Compile Include="HangupsSystem\NotificationHelper.cs" />
-    <Compile Include="HangupsSystem\SettingsHelper.cs" />
+    <Compile Include="Core\Auth.cs" />
+    <Compile Include="Core\NotificationHelper.cs" />
+    <Compile Include="Core\SettingsHelper.cs" />
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>

--- a/Hangups/MainPage.xaml.cs
+++ b/Hangups/MainPage.xaml.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text;
 using Windows.Foundation;
@@ -15,11 +14,7 @@ using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
-using Newtonsoft.Json;
-using System.Net;
-using System.Dynamic;
-using Hangups.HangupsSystem;
-using Newtonsoft.Json.Linq;
+using Hangups.Core;
 
 // The Blank Page item template is documented at http://go.microsoft.com/fwlink/?LinkId=402352&clcid=0x409
 
@@ -30,130 +25,10 @@ namespace Hangups
     /// </summary>
     public sealed partial class MainPage : Page
     {
-        private static string oAuth_Scope = "https://www.google.com/accounts/OAuthLogin";
-        private static string client_secret = "KWsJlkaMn1jGLxQpWxMnOox-";
-        private static string client_id = "936475272427.apps.googleusercontent.com";
-        private static string redirect_uri = "urn:ietf:wg:oauth:2.0:oob";
-        private static string login_url = "https://accounts.google.com/o/oauth2/auth?{0}";
-        private static string token_request_url = "https://accounts.google.com/o/oauth2/token";
-
-        private string access_token;
-        private CookieContainer responseCookies;
-
         public MainPage()
         {
             this.InitializeComponent();
-            if(loadRefreshToken() != string.Empty)
-            {
-                AuthenticateWithRefreshToken();
-            }
-            else
-            {
-                AuthenticateWithGoogle();
-            }
-        }
-
-        private async void AuthenticateWithGoogle()
-        {
-            var startUri = new Uri(string.Format(login_url, formatLoginURL()));
-            Uri EndUri = new Uri("https://accounts.google.com/o/oauth2/approval?");
-            try
-            {
-                WebAuthenticationResult WebAuthenticationResult = await WebAuthenticationBroker.AuthenticateAsync(WebAuthenticationOptions.UseTitle, startUri, EndUri);
-                if (WebAuthenticationResult.ResponseStatus == WebAuthenticationStatus.Success)
-                {
-                    AuthenticateWithToken(WebAuthenticationResult.ResponseData.ToString().Split('=')[1]);
-                }
-                else if (WebAuthenticationResult.ResponseStatus == WebAuthenticationStatus.ErrorHttp)
-                {
-                    //
-                }
-                else
-                {
-                    //
-                }
-            }
-
-
-            catch (Exception Error)
-            {
-               // rootPage.NotifyUser(Error.Message, NotifyType.ErrorMessage);
-            } 
-}
-
-        private async void AuthenticateWithRefreshToken()
-        {
-            var refreshToken = loadRefreshToken();
-            HttpClient aClient = new HttpClient();
-            var body = new FormUrlEncodedContent(new[]
-            {
-                new KeyValuePair<string, string>("client_id", client_id),
-                new KeyValuePair<string, string>("client_secret", client_secret),
-                new KeyValuePair<string, string>("grant_type", "refresh_token"),
-                new KeyValuePair<string, string>("refresh_token", refreshToken)
-            });
-            var response = await aClient.PostAsync(token_request_url, body);
-            response.EnsureSuccessStatusCode();
-
-            var resultContent = await response.Content.ReadAsStringAsync();
-            JObject returnedData = JObject.Parse(resultContent);
-            access_token = (string)returnedData.SelectToken("access_token"); // This is what we do auth with. I will probably store this somewhere
-            GetSessionCookies();
-        }
-
-        private async void GetSessionCookies()
-        {
-            HttpClient aClient = new HttpClient();
-            aClient.DefaultRequestHeaders.Add("Authorization", string.Format("Bearer {0}", access_token));
-            var r = await aClient.GetAsync("https://accounts.google.com/accounts/OAuthLogin?source=hangups&issueuberauth=1");
-            r.EnsureSuccessStatusCode();
-            var uberAuth = await r.Content.ReadAsStringAsync();
-            r = await aClient.GetAsync(String.Format("https://accounts.google.com/MergeSession?service=mail&continue=http://www.google.com&uberauth={0}", uberAuth));
-            r.EnsureSuccessStatusCode();
-            IEnumerable<string> cookies;
-            responseCookies = new CookieContainer();
-            if (r.Headers.TryGetValues("set-cookie", out cookies))
-            {
-                foreach (var c in cookies)
-                {
-                    responseCookies.SetCookies(r.RequestMessage.RequestUri, c);
-                }
-            }
-        }
-
-        private async void AuthenticateWithToken(string authToken)
-        {
-            HttpClient aClient = new HttpClient();
-            var body = new FormUrlEncodedContent(new[]
-            {
-                new KeyValuePair<string, string>("client_id", client_id),
-                new KeyValuePair<string, string>("client_secret", client_secret),
-                new KeyValuePair<string, string>("code", authToken),
-                new KeyValuePair<string, string>("grant_type", "authorization_code"),
-                new KeyValuePair<string, string>("redirect_uri", redirect_uri),
-            });
-
-            var response = await aClient.PostAsync(token_request_url, body);
-            response.EnsureSuccessStatusCode();
-
-            var resultContent = await response.Content.ReadAsStringAsync();
-            JObject returnedData = JObject.Parse(resultContent);
-            access_token = (string)returnedData.SelectToken("access_token"); // This is what we do auth with. I will probably store this somewhere
-            saveRefreshToken((string)returnedData.SelectToken("refresh_token"));
-            GetSessionCookies();
-        }
-
-        private string formatLoginURL()
-        {
-            return "client_id=" + Uri.EscapeDataString(client_id) + "&redirect_uri=" + Uri.EscapeDataString(redirect_uri) + "&response_type=code&scope=" + Uri.EscapeDataString(oAuth_Scope);
-        }
-
-        private string loadRefreshToken() {
-            return SettingsHelper.GetStringSetting("refresh_token");
-        }
-
-        private void saveRefreshToken(string token) {
-            SettingsHelper.StoreSetting("refresh_token", token);
+            Auth.PerformOauth();
         }
     }
 }


### PR DESCRIPTION
Auth has a single public method called "PerformOauth" that handles
whether or not to show the oauth broker to the user. all other methods
are called behind the scenes. Also, added an error message to the
notification helper. This makes it so errors in the auth layer(or
anywhere) can be handled with a message.

Makes the code on the main page a bit cleaner. Also Hangups.HangupsSystem was a bit weird, so renamed to Core.
